### PR TITLE
chore(core): remove style prop on angular:lib gen

### DIFF
--- a/workspace.json
+++ b/workspace.json
@@ -486,7 +486,6 @@
       "e2eTestRunner": "cypress"
     },
     "@nrwl/angular:library": {
-      "style": "scss",
       "linter": "eslint",
       "unitTestRunner": "jest"
     },


### PR DESCRIPTION
Solve the issue where Nx is picking up the outdated default props for generating angular libraries.
The `style` property on `@nrwl/angular:lib` makes the generation process erroring with:

```
nx generate @nrwl/angular:lib mylib --directory store --dry-run
'style' is not found in schema
```