### PR TITLE
fix(lab 14): update getScopes function to iterate map

### DIFF
--- a/docs/lab14/LAB.md
+++ b/docs/lab14/LAB.md
@@ -45,7 +45,7 @@
 
    ```typescript
    function getScopes(projectMap: Map<string, ProjectConfiguration>) {
-     const projects: any[] = Object.values(projectMap);
+     const projects: any[] = Array.from(projectMap.values());
      const allScopes: string[] = projects
        .map((project) =>
          project.tags


### PR DESCRIPTION
`Object.values(Map)` does not return an array of the values. use `Array.from(Map.values())`

![demo of iterating a Map](https://user-images.githubusercontent.com/23272162/161804158-6e773679-f957-4cf4-826d-272520a0b2c6.png)
